### PR TITLE
Fix issue #4 (old call url format) and #5 (unsupported browser url changed)

### DIFF
--- a/pages/hello.py
+++ b/pages/hello.py
@@ -23,7 +23,7 @@ class HelloPage(Page):
     _unsupported_browser_firefox_link_locator = (By.CSS_SELECTOR, '#main a')
 
     def go_to_page(self):
-        self.url = '%s/#call/%s' % (self.base_url, hash(datetime.datetime.now()))
+        self.url = '%s/c/%s' % (self.base_url, hash(datetime.datetime.now()))
         self.selenium.get(self.url)
         WebDriverWait(self.selenium, self.timeout).until(EC.visibility_of_element_located(self._page_content_locator))
 

--- a/tests/test_hello.py
+++ b/tests/test_hello.py
@@ -28,4 +28,4 @@ class TestHelloPage:
         hello_page.go_to_page()
         Assert.equal('Oops!\nFirefox Hello only works in browsers that support WebRTC\nDownload Firefox to make free audio and video calls!\nGet Firefox',
                      hello_page.unsupported_browser_message_text)
-        Assert.equal('https://www.mozilla.org/firefox/', hello_page.unsupported_browser_firefox_link_href)
+        Assert.contains('https://www.mozilla.org/firefox/', hello_page.unsupported_browser_firefox_link_href)


### PR DESCRIPTION
This fixes issue #4 and #5 which were both changed in the most recent release of the loop-client.