### PR TITLE
Replace unittestzero with native assert and change default baseurl to dev

### DIFF
--- a/mozwebqa.cfg
+++ b/mozwebqa.cfg
@@ -1,3 +1,3 @@
 [DEFAULT]
 api = webdriver
-baseurl = https://hello.firefox.com
+baseurl = https://loop-webapp-dev.stage.mozaws.net/

--- a/pages/page.py
+++ b/pages/page.py
@@ -11,7 +11,6 @@ import re
 import time
 
 import requests
-from unittestzero import Assert
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.common.exceptions import NoSuchElementException
 from selenium.common.exceptions import ElementNotVisibleException
@@ -35,9 +34,7 @@ class Page(object):
     def is_the_current_page(self):
         if self._page_title:
             page_title = self.page_title
-            Assert.equal(page_title, self._page_title,
-                         "Expected page title: %s. Actual page title: %s" %
-                         (self._page_title, page_title))
+            assert page_title == self._page_title
 
     @property
     def url_current_page(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,4 @@
 ## on Mozilla WebQA projects
 
 pytest-mozwebqa
-PyYAML==3.10
 selenium
-UnittestZero

--- a/tests/test_hello.py
+++ b/tests/test_hello.py
@@ -5,7 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import pytest
-from unittestzero import Assert
 from pages.hello import HelloPage
 
 
@@ -15,17 +14,18 @@ class TestHelloPage:
     def test_supported_browser(self, mozwebqa):
         hello_page = HelloPage(mozwebqa)
         hello_page.go_to_page()
-        Assert.true(hello_page.is_header_title_visible)
-        Assert.true(hello_page.is_start_call_button_visible)
-        Assert.true(hello_page.is_footer_logo_visible)
-        Assert.equal('Firefox Hello', hello_page.header_title_text)
-        Assert.equal('Start', hello_page.start_call_button_text)
-        Assert.equal(hello_page.actual_page_url, hello_page.current_url_text)
+        assert hello_page.is_header_title_visible
+        assert hello_page.is_start_call_button_visible
+        assert hello_page.is_footer_logo_visible
+        assert 'Firefox Hello' == hello_page.header_title_text
+        assert 'Start' == hello_page.start_call_button_text
+        assert hello_page.current_url_text == hello_page.actual_page_url
 
     @pytest.mark.nondestructive
     def test_unsupported_browser(self, mozwebqa):
         hello_page = HelloPage(mozwebqa)
         hello_page.go_to_page()
-        Assert.equal('Oops!\nFirefox Hello only works in browsers that support WebRTC\nDownload Firefox to make free audio and video calls!\nGet Firefox',
-                     hello_page.unsupported_browser_message_text)
-        Assert.contains('https://www.mozilla.org/firefox/', hello_page.unsupported_browser_firefox_link_href)
+        assert 'Oops!\nFirefox Hello only works in browsers that support WebRTC\n' \
+               'Download Firefox to make free audio and video calls!\nGet Firefox' == \
+               hello_page.unsupported_browser_message_text
+        assert 'https://www.mozilla.org/firefox/' in hello_page.unsupported_browser_firefox_link_href


### PR DESCRIPTION
This also removes the PyYAML requirement as it isn't used

One of the Hello tests failed yesterday and I noticed that the failure message was not helpful in debugging the issue because it was using `Assert.equal`. I decided to replace `unittestzero` with native `assert`s as we have said we would do with all of our projects.

Also, in speaking to Standard8 it was decided we should run these tests in dev, so I updated the jobs and also changed the default `baseurl` in `mozwebqa.cfg`. I did that in a separate commit, but it's included in this PR.

Passing adhoc runs can be seen at [1] and [2].

@m8ttyB | @rbillings r?

[1] https://webqa-ci.mozilla.com/view/Hello/job/hello.prod.supported.saucelabs.adhoc/1/
[2] https://webqa-ci.mozilla.com/view/Hello/job/hello.prod.unsupported.saucelabs.adhoc/3/