### PR TITLE
Fix an intermittent failure for the title not being visible - wait for the element to be visible before moving on.

### DIFF
--- a/pages/hello.py
+++ b/pages/hello.py
@@ -40,7 +40,8 @@ class HelloPage(Page):
 
     @property
     def is_hello_logo_visible(self):
-        return self.is_element_visible(*self._hello_logo_locator)
+        self.wait_for_element_visible(*self._hello_logo_locator)
+        return True
 
     @property
     def unsupported_browser_message_text(self):


### PR DESCRIPTION
We've seen a couple of intermittent failures recently:

_____________________ TestHelloPage.test_supported_browser _____________________
tests/test_hello.py:17: in test_supported_browser
    assert hello_page.is_header_title_visible
E   assert <pages.hello.HelloPage object at 0x7f6044b34950>.is_header_title_visible

I think this is due to the fact that there's now a intermediate display (of nothing) on load where we might not display the logo & title straight away.

The best way to handle this seems to be to add a wait before returning the element.