### PR TITLE
Update to pytest-selenium 1.2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 pytest==2.7.3
-pytest-selenium
+pytest-selenium>=1.2.0rc1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,11 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import pytest
+
+
+@pytest.fixture(scope='session')
+def session_capabilities(session_capabilities):
+    session_capabilities.setdefault('tags', []).append('hello')
+    return session_capabilities


### PR DESCRIPTION
There's a breaking change in v1.2.0, so I've released a candidate so that we can update our suites before the general release. @stephendonner r?